### PR TITLE
Update BlogHomeScreen to refresh data on pull-down

### DIFF
--- a/src/screens/Blog/HomeScreen.tsx
+++ b/src/screens/Blog/HomeScreen.tsx
@@ -9,7 +9,14 @@ import colors from '@theme/colors';
 import { text } from '@theme/text';
 import { observer } from 'mobx-react-lite';
 import { useEffect } from 'react';
-import { ActivityIndicator, FlatList, ListRenderItem, Text, View } from 'react-native';
+import {
+  ActivityIndicator,
+  FlatList,
+  ListRenderItem,
+  Text,
+  View,
+  RefreshControl,
+} from 'react-native';
 
 const BlogHomeScreen = () => {
   const { navigate } = useNavigation<NavigationProp<BlogStackNavigatorParamList>>();
@@ -61,6 +68,14 @@ const BlogHomeScreen = () => {
         onEndReached={postStore.increasePage}
         ListHeaderComponent={RenderListHeader}
         ListEmptyComponent={<ActivityIndicator size="large" color={colors.zinc[600]} />}
+        refreshControl={
+          <RefreshControl
+            refreshing={postStore.loading}
+            onRefresh={async () => {
+              await postStore.getPosts();
+            }}
+          />
+        }
       />
     </View>
   );

--- a/src/screens/Blog/HomeScreen.tsx
+++ b/src/screens/Blog/HomeScreen.tsx
@@ -72,6 +72,8 @@ const BlogHomeScreen = () => {
           <RefreshControl
             refreshing={postStore.loading}
             onRefresh={async () => {
+              postStore.clearAll();
+              postStore.page = 1;
               await postStore.getPosts();
             }}
           />

--- a/src/screens/Blog/HomeScreen.tsx
+++ b/src/screens/Blog/HomeScreen.tsx
@@ -13,9 +13,9 @@ import {
   ActivityIndicator,
   FlatList,
   ListRenderItem,
+  RefreshControl,
   Text,
   View,
-  RefreshControl,
 } from 'react-native';
 
 const BlogHomeScreen = () => {
@@ -29,6 +29,19 @@ const BlogHomeScreen = () => {
     },
     [],
   );
+
+  const onEndReached = () => {
+    if (postStore.pullToRefresh) {
+      return;
+    }
+
+    postStore.increasePage();
+  };
+
+  const onRefresh = () => {
+    postStore.setPullToRefresh(true);
+    postStore.getPosts();
+  };
 
   const RenderItem: ListRenderItem<PostType> = ({ item: post }) => (
     <View className="px-5">
@@ -59,24 +72,16 @@ const BlogHomeScreen = () => {
       )}
       <FlatList
         windowSize={6}
-        key="blogHome"
         removeClippedSubviews
         initialNumToRender={6}
         maxToRenderPerBatch={6}
         renderItem={RenderItem}
+        onEndReached={onEndReached}
         data={postStore.listingPosts}
-        onEndReached={postStore.increasePage}
         ListHeaderComponent={RenderListHeader}
         ListEmptyComponent={<ActivityIndicator size="large" color={colors.zinc[600]} />}
         refreshControl={
-          <RefreshControl
-            refreshing={postStore.loading}
-            onRefresh={async () => {
-              postStore.clearAll();
-              postStore.page = 1;
-              await postStore.getPosts();
-            }}
-          />
+          <RefreshControl refreshing={postStore.pullToRefresh} onRefresh={onRefresh} />
         }
       />
     </View>


### PR DESCRIPTION
### Changes
- Added `RefreshControl` to `BlogHomeScreen` to enable pull-to-refresh functionality.
- Triggered `postStore.getPosts` to fetch new data from the API after clearing the posts.

### Why?
This improves the user experience by allowing users to fetch the latest data by pulling down on the screen.
